### PR TITLE
libem.so missing in both .zip and tar.gz

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,9 @@ jobs:
       - name: Build binary
         run: |
           make
-          zip libem.zip ./bin/libem.so
-          tar -czvf libem.tar.gz ./bin/libem.so 
+          cp ./bin/libem.so .
+          zip libem.zip ./libem.so
+          tar -czvf libem.tar.gz ./libem.so 
 
       - name: Upload Release Asset (.zip)
         uses: actions/upload-release-asset@v1.0.2


### PR DESCRIPTION
Due to the automated zip and tar process pulling the shared library from
./bin, libem.so was not present at all in libem.tar.gz and present in
./bin/libem.so in libem.zip (wrong directory). This now moves the shared
library into the current directory allowing the compression tools to
correctly load the files.